### PR TITLE
Use ssh variable instead of file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "hcloud_ssh_key" "this" {
   name       = "terraform-hcloud-rke"
-  public_key = file(var.ssh_public_key_path)
+  public_key = var.ssh_public_key
 }
 
 resource "hcloud_server" "this" {
@@ -16,7 +16,7 @@ resource "hcloud_server" "this" {
     connection {
       host        = self.ipv4_address
       type        = "ssh"
-      private_key = file(var.ssh_private_key_path)
+      private_key = var.ssh_private_key
     }
     source      = "${path.module}/files/install.sh"
     destination = "/tmp/install.sh"
@@ -26,7 +26,7 @@ resource "hcloud_server" "this" {
     connection {
       host        = self.ipv4_address
       type        = "ssh"
-      private_key = file(var.ssh_private_key_path)
+      private_key = var.ssh_private_key
     }
     inline = [
       "chmod +x /tmp/install.sh",
@@ -54,7 +54,8 @@ resource "rke_cluster" "this" {
       address = nodes.value.address
       user    = "root"
       role    = nodes.value.role
-      ssh_key = file(var.ssh_private_key_path)
+      ssh_key = var.ssh_private_key
+      hostname_override = nodes.value.name
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
-variable "ssh_private_key_path" {
-  description = "SSH private key path"
+variable "ssh_private_key" {
+  description = "SSH private key"
   default     = "~/.ssh/id_rsa"
 }
 
-variable "ssh_public_key_path" {
-  description = "SSH public key path"
+variable "ssh_public_key" {
+  description = "SSH public key"
   default     = "~/.ssh/id_rsa.pub"
 }
 


### PR DESCRIPTION
Files can still be referenced by the 'file()' call, and entire keys, such as coming from the TLS provider, Vault and similar tools can also be referenced