### PR TITLE
Bump provider to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You might want to include the CSI driver for automatic provisioning of volumes b
 | Name | Version |
 |------|---------|
 | hcloud | ~> 1.14 |
-| rke | ~> 0.14 |
+| rke | ~> 1.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hcloud   = "~> 1.14"
     local    = "~> 1.4"
-    rke      = "~> 0.14"
+    rke      = "~> 1.0"
     template = "~> 2.1"
     null     = "~> 2.1"
   }


### PR DESCRIPTION
Rancher has released version 1.0.0 of their terraform provider with bugfixes.

This PR updates the version of provider to be used.